### PR TITLE
Show Player in Lobby

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -11,6 +11,9 @@
       <SelectionState runConfigName="MainActivity (3)">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="LobbyPlayerItemPreview">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -8,12 +8,6 @@
       <SelectionState runConfigName="MainActivity">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="MainActivity (3)">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="LobbyPlayerItemPreview">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,6 +110,9 @@ sonar {
 
 dependencies {
 
+    implementation(libs.ktor.client.content.negotiation)
+    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.7")
+    implementation(libs.kotlinx.serialization.json.v180)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/src/main/java/se2/hanabi/app/lobby/LobbyActivity.kt
+++ b/app/src/main/java/se2/hanabi/app/lobby/LobbyActivity.kt
@@ -31,6 +31,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -54,12 +56,13 @@ class LobbyActivity : ComponentActivity() {
         val receivedLobbyCode = intent.getStringExtra("lobbyCode") ?: "Kein Code"
 
         viewModel.setLobbyCode(receivedLobbyCode)
+        viewModel.fetchPlayers()
 
         setContent{
             ClientTheme {
+                val players by viewModel.players.collectAsState()
                 LobbyScreen(
-                    //TODO: add dynamic data
-                    playerList = listOf("Player1","Player2","Player3", "Player4", "Player5"),
+                    playerList = players,
                     lobbyCode = viewModel.lobbyCode,
                     onLeaveLobby = { finish()},
                     onStartGame = {navigateToGame()}

--- a/app/src/main/java/se2/hanabi/app/lobby/LobbyActivity.kt
+++ b/app/src/main/java/se2/hanabi/app/lobby/LobbyActivity.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 
@@ -56,7 +57,7 @@ class LobbyActivity : ComponentActivity() {
         val receivedLobbyCode = intent.getStringExtra("lobbyCode") ?: "Kein Code"
 
         viewModel.setLobbyCode(receivedLobbyCode)
-        viewModel.fetchPlayers()
+        viewModel.startPlayerSync()
 
         setContent{
             ClientTheme {

--- a/app/src/main/java/se2/hanabi/app/lobby/LobbyViewModel.kt
+++ b/app/src/main/java/se2/hanabi/app/lobby/LobbyViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import io.ktor.client.request.get
+import kotlinx.coroutines.delay
 
 
 class LobbyViewModel : ViewModel() {
@@ -34,6 +35,7 @@ class LobbyViewModel : ViewModel() {
             try {
                 val code = _lobbyCode.value ?: return@launch
                 val response: List<String> =  client.get("http://10.0.2.2:8080/lobby/$code/players").body()
+                println("Fetched players: $response") // Debugging line
                 _players.value = response
             }catch (e: Exception){
                 e.printStackTrace()
@@ -41,4 +43,14 @@ class LobbyViewModel : ViewModel() {
             }
         }
     }
+
+    fun startPlayerSync(intervalMillis : Long = 1000L){
+        viewModelScope.launch {
+            while (true) {
+                fetchPlayers()
+                delay(intervalMillis)
+            }
+        }
+    }
 }
+

--- a/app/src/main/java/se2/hanabi/app/lobby/LobbyViewModel.kt
+++ b/app/src/main/java/se2/hanabi/app/lobby/LobbyViewModel.kt
@@ -3,15 +3,42 @@ package se2.hanabi.app.lobby
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import io.ktor.client.request.get
 
 
 class LobbyViewModel : ViewModel() {
 
+    private val _players = MutableStateFlow<List<String>>(emptyList())
+    val players: StateFlow<List<String>> = _players
+
     private val _lobbyCode = mutableStateOf<String?>(null)
+
     val lobbyCode: String?
         get() = _lobbyCode.value
 
+    private val client = HttpClient(CIO)
+
     fun setLobbyCode(code: String) {
         _lobbyCode.value = code
+    }
+
+    fun fetchPlayers() {
+        viewModelScope.launch {
+            try {
+                val code = _lobbyCode.value ?: return@launch
+                val response: List<String> =  client.get("http://10.0.2.2:8080/lobby/$code/players").body()
+                _players.value = response
+            }catch (e: Exception){
+                e.printStackTrace()
+                _players.value = emptyList()
+            }
+        }
     }
 }

--- a/app/src/main/java/se2/hanabi/app/lobby/LobbyViewModel.kt
+++ b/app/src/main/java/se2/hanabi/app/lobby/LobbyViewModel.kt
@@ -1,6 +1,5 @@
 package se2.hanabi.app.lobby
 
-
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -12,6 +11,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import io.ktor.client.request.get
 import kotlinx.coroutines.delay
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
 
 
 class LobbyViewModel : ViewModel() {
@@ -24,7 +26,14 @@ class LobbyViewModel : ViewModel() {
     val lobbyCode: String?
         get() = _lobbyCode.value
 
-    private val client = HttpClient(CIO)
+    private val client = HttpClient(CIO) {
+        install(ContentNegotiation) {
+            json(Json{
+                ignoreUnknownKeys = true
+                isLenient = true
+            })
+        }
+    }
 
     fun setLobbyCode(code: String) {
         _lobbyCode.value = code
@@ -35,7 +44,6 @@ class LobbyViewModel : ViewModel() {
             try {
                 val code = _lobbyCode.value ?: return@launch
                 val response: List<String> =  client.get("http://10.0.2.2:8080/lobby/$code/players").body()
-                println("Fetched players: $response") // Debugging line
                 _players.value = response
             }catch (e: Exception){
                 e.printStackTrace()


### PR DESCRIPTION
After creating or joining a lobby, fetchPlayers() is automatically called to load the current player list from the server.
The UI now shows all players in the lobby, including your own player immediately after joining.
This means that the player overview is always up-to-date and corresponds to the server status.