### PR TITLE
Player list updates if player leaves lobby

### DIFF
--- a/app/src/main/java/se2/hanabi/app/lobby/LobbyActivity.kt
+++ b/app/src/main/java/se2/hanabi/app/lobby/LobbyActivity.kt
@@ -92,7 +92,16 @@ class LobbyActivity : ComponentActivity() {
                     playerList = players,
                     lobbyCode = lobbyCode,
                     isHost = isHostState,
-                    onLeaveLobby = { finish() },
+                    onLeaveLobby = {
+                        val lobbyc = viewModel.lobbyCode
+                        val playerid = viewModel.getPlayerId()
+                            if ( lobbyc != null && playerid!= null && playerid !=-1){
+                                leaveLobbyRequest(lobbyc, playerid){
+                                    finish()
+                                }
+                            } else {
+                        finish()
+            }},
                     onStartGame = { lobbyCode?.let { startGameRequest(it) } },
                 )
             }
@@ -120,6 +129,25 @@ class LobbyActivity : ComponentActivity() {
                     }
                 }
             } catch (e: Exception) {
+            }
+        }
+    }
+
+    private fun leaveLobbyRequest(lobbyCode: String, playerId: Int, onComplete: () -> Unit){
+        lifecycleScope.launch {
+            try {
+                val client = HttpClient(CIO)
+                val response: HttpResponse = client.get("http://10.0.2.2:8080/leave-lobby/$lobbyCode/$playerId")
+
+                if (response.status == HttpStatusCode.OK){
+                    println("Leaving lobby server notification")
+                } else {
+                    println("Failed to nofity")
+                }
+            } catch (e: Exception){
+                e.printStackTrace()
+            } finally {
+                onComplete()
             }
         }
     }
@@ -189,15 +217,12 @@ class LobbyActivity : ComponentActivity() {
                                     .clip(CircleShape)
                                     .background(Color.DarkGray)
                             ){
-                                //if (player == username){
-
                                 Image( painter = painterResource(id = player.avatarResID),
                                         contentDescription = "Avatar",
                                         contentScale = ContentScale.Crop,
                                         modifier = Modifier.fillMaxSize()
                                     )
                                 }
-                            //}
 
                             Text(
                                 text = player.name,


### PR DESCRIPTION
When a player in LobbyActivity clicks the "Leave Lobby" button:
The client sends a notification to the server indicating the player is leaving
The player is removed from the server-side list of players in that lobby
The LobbyActivity screen is closed for the leaving player
Other players remaining in the lobby see an updated player list that no longer includes the player who left
Player who leaves and rejoins the same (or another) lobby will appear only once in the player list