### PR TITLE
fixes discard on empty discard stack click

### DIFF
--- a/app/src/main/java/se2/hanabi/app/gamePlayUI/GameBoardUI.kt
+++ b/app/src/main/java/se2/hanabi/app/gamePlayUI/GameBoardUI.kt
@@ -229,7 +229,8 @@ fun DiscardedCardsStack(
 ) {
     if (lastDiscardedCard == null) {
         EmptyStack(
-            cardSizeDp = cardSizeDp
+            cardSizeDp = cardSizeDp,
+            onClick = onClick
         )
     } else {
         CardItem(

--- a/app/src/main/java/se2/hanabi/app/gamePlayUI/GameBoardUI.kt
+++ b/app/src/main/java/se2/hanabi/app/gamePlayUI/GameBoardUI.kt
@@ -300,7 +300,7 @@ fun DiscardedCardsStack(
     if (lastDiscardedCard == null) {
         EmptyStack(
             cardSizeDp = cardSizeDp, 
-            onClick = onClick
+            onClick = onClick,
             modifier = stackModifier
 
         )


### PR DESCRIPTION
Allows to players to discard card by clicking on the empty discarded stack. Make behaviour coherent with clicking on the discard pile when there is already a card there.